### PR TITLE
feat: Display Profit Page from orders

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -10,6 +10,6 @@ class Settings:
     ALPACA_DATA_URL: str = "https://data.alpaca.markets"
     WEBHOOK_SECRET: str = os.getenv("WEBHOOK_SECRET", "supersecret")
     RETRY_LIMIT: int = 2
-    RETRY_BACKOFF_SECONDS: int = 2
+    RETRY_BACKOFF_SECONDS: int = 5
 
 settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from app.schemas import TradingViewWebhook, OrderResponse
 
 from app.alpaca_client import AlpacaClient
 from app.config import settings
-from app.routers import orders, webhooks, positions
+from app.routers import orders, webhooks, positions, json
 from . import models
 from sqlalchemy.orm import Session
 from app.database import get_db, SessionLocal, engine
@@ -31,6 +31,7 @@ app.mount("/assets", StaticFiles(directory="frontend/dist/assets"), name="assets
 app.include_router(orders.router, prefix="/api/orders", tags=["orders"])
 app.include_router(webhooks.router, prefix="/api/webhooks", tags=["webhooks"])
 app.include_router(positions.router, prefix="/api/positions", tags=["positions"])
+app.include_router(json.router, prefix="/api/json", tags=["json"])
 
 @app.get("/{full_path:path}")
 async def catch_all(full_path: str, request: Request):

--- a/app/routers/json.py
+++ b/app/routers/json.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+from pydantic import BaseModel
+from app.models import Webhook
+from app.database import get_db  # you should already have this
+from app.alpaca_client import AlpacaClient  # assuming you have this client set up
+from typing import Optional
+from app.schemas import PositionSchema
+from app.order_manager import manage_order
+from datetime import date
+
+
+
+router = APIRouter()
+alpaca = AlpacaClient()
+
+@router.get("/meta")
+async def getJson():
+
+    print("Fetching positions from the Alpaca...")
+
+    return {
+        "name": "Hello"
+    }
+    
+    

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Webhooks from "./pages/Webhooks";
 import Nav from "./components/Nav";
 import Orders from "./pages/Orders";
 import Positions from "./pages/Positions";
+import Profits from "./pages/Profits"
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
           <Route path="/orders" element={<Orders />} />
           <Route path="/webhooks" element={<Webhooks />} />
           <Route path="/positions" element={<Positions />} />
+          <Route path="/profits" element={<Profits />} />
         </Routes>      
     </BrowserRouter>
     </div>

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -15,7 +15,8 @@ function Nav() {
       <Link className="mr-4" to="/positions">
         Positions
       </Link>
-      <Link to="/webhooks">Webhooks</Link>
+      <Link className="mr-4" to="/webhooks">Webhooks</Link>
+      <Link to="/profits">Profits</Link>
     </nav>
     </div>
   );

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -9,7 +9,7 @@ type LogType = {
   price: number;
   date: string;
   type: string;
-  status: "failed" | "polling" | "filled" | "expiry";
+  status: string;
   limitPrice: number;
   position_intent: string;
 };
@@ -34,9 +34,11 @@ function App() {
     try {
       setLoading(true);
       const response = await axios.get<LogType[]>(
-        "/api/orders/live"
+        "http://localhost:8000/api/orders/live"
       );
-      setLogs(response.data);
+      let data = response.data;
+      data = data.filter((log) => log.status !== "canceled");
+      setLogs(data);
       setError(null);
     } catch (err) {
       setError("Failed to fetch orders");

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -30,7 +30,7 @@ function Positions() {
     try {
       setLoading(true);
       const response = await axios.get<LogType[]>(
-        "/api/positions/live"
+        "http://localhost:8000/api/positions/live"
       );
       setLogs(response.data);
       setError(null);

--- a/frontend/src/pages/Profits.tsx
+++ b/frontend/src/pages/Profits.tsx
@@ -1,0 +1,116 @@
+import Table, { Column } from "../components/Table";
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+type LogType = {
+  ticker: string;
+  action: string;
+  quantity: number;
+  price: number;
+  date: string;
+  type: string;
+  status: string;
+  limitPrice: number;
+  position_intent: string;
+  profit?: number; // Optional profit field
+};
+
+const columns: Column<LogType>[] = [
+  { key: "ticker", label: "Ticker", sortable: true },
+  { key: "action", label: "Action", sortable: true },
+  { key: "quantity", label: "Quantity", sortable: true },
+  { key: "type", label: "Type", sortable: true },
+  { key: "limitPrice", label: "Limit Price", sortable: true },
+  { key: "status", label: "Status" },
+  { key: "date", label: "Date", sortable: true },
+  // { key: "position_intent", label: "Position Intent" },
+  { key: "profit", label: "Profit", sortable: true }, // Added profit column
+];
+
+function Profits() {
+  const [logs, setLogs] = useState<LogType[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchLogs = async () => {
+    try {
+      setLoading(true);
+      const response = await axios.get<LogType[]>(
+        "http://localhost:8000/api/orders/live"
+      );
+      let data = response.data;
+      data = data.filter((log) => log.status === "filled");
+      let profits = calcProfits(data);
+      setLogs(profits);
+      setError(null);
+    } catch (err) {
+      setError("Failed to fetch orders");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const calcProfits = (logs: LogType[]): LogType[] => {
+    let reorderedLogs: LogType[] = logs;
+    // reorderedLogs = logs.sort((a, b) => {
+    //   return new Date(a.date).getTime() - new Date(b.date).getTime();
+    // });
+    let curprice: { [key: string]: number } = {};
+    let curcount: { [key: string]: number } = {};
+    for (let i = reorderedLogs.length - 1; i >= 0; i --) {
+      let ticker = reorderedLogs[i].ticker;
+      let action = reorderedLogs[i].action;
+      let quantity = Number(reorderedLogs[i].quantity) || 0;
+      let price = Number(reorderedLogs[i].limitPrice) || 0;
+      if (curcount[ticker] === undefined) curcount[ticker] = 0;
+      if (curprice[ticker] === undefined) curprice[ticker] = 0;
+      console.log(
+        action,
+        ticker,
+        quantity,
+        price,
+        curprice[ticker],
+        curcount[ticker]
+      );
+      if (quantity === 0) continue;
+      if (action === "buy") {
+        curprice[ticker] =
+          (price * quantity + curprice[ticker] * curcount[ticker]) /
+          (quantity + curcount[ticker]);
+
+        curcount[ticker] = quantity + curcount[ticker];
+        reorderedLogs[i].profit = 0;
+        // console.log(curprice[ticker]);
+      } else if (action === "sell") {
+        let profit = (price - curprice[ticker]) * quantity;
+        profit = Math.round(profit * 100) / 100;
+        curcount[ticker] = curcount[ticker] - quantity;
+        reorderedLogs[i].profit = profit;
+        if (curcount[ticker] === 0) {
+          delete curprice[ticker];
+          delete curcount[ticker];
+        }
+      }
+    }
+    return reorderedLogs;
+  };
+
+  useEffect(() => {
+    fetchLogs();
+    // const interval = setInterval(fetchLogs, 10000); // Auto-refresh every 10 seconds
+    // return () => clearInterval(interval); // Cleanup on unmount
+  }, []);
+  return (
+    <div className="w-full min-h-screen pt-10">
+      {loading && <div className="text-center">Loading...</div>}
+      {error && <div className="text-red-500 text-center">{error}</div>}
+      {!loading && !error && (
+        <div className="max-w-6xl mx-auto bg-white shadow-lg rounded-lg">
+          <Table columns={columns} data={logs} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Profits;

--- a/frontend/src/pages/Webhooks.tsx
+++ b/frontend/src/pages/Webhooks.tsx
@@ -36,7 +36,7 @@ function Webhooks() {
     try {
       setLoading(true);
       const response = await axios.get<LogType[]>(
-        "/api/webhooks/db"
+        "http://localhost:8000/api/webhooks/db"
       );
       console.log(response.data);
       let data = response.data.sort((a, b) => {


### PR DESCRIPTION
Description
This update implements a new feature that calculates and displays profit based on historical order data retrieved from Alpaca. The logic analyzes all closed and filled orders from the earliest to the most recent, calculates the average buy price for the current position, and displays the resulting profit after a sale order is executed.

Key Changes
Fetch order history data from Alpaca API.

Process and filter for closed and filled orders only.

Compute average entry prices for current holdings.

Calculate and display realized profit upon sell order completion.

Purpose
This enhancement aims to provide clear, real-time visibility into trading performance by showing profit after each closed position, enabling better tracking and analysis of executed trades.